### PR TITLE
wrap cli value in single quotes if it contains space

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -151,10 +151,15 @@ class AppiumLauncher {
             ret.push(this._lowerCamelToOptionName(key));
 
             if (typeof value !== 'boolean' && value !== null) {
-                ret.push(value.toString());
+                ret.push(this._sanitizeCliValue(value));
             }
         }
         return ret;
+    }
+    
+    _sanitizeCliValue (v: any): string {
+        const valueStr = String(v);
+        return /\s/.test(valueStr) ? `'${valueStr}'` : valueStr;
     }
 
     _debugLog (msg: string) {


### PR DESCRIPTION
```javascript
appium: {
    args: {
        deviceName: 'iPhone 5s'
    }
} 
```
converted as the following invalid bash code
```bash
appium --device-name iPhone 5s # iPhone 5s -> 'iPhone 5s'
```